### PR TITLE
Fix issue about compiling a Quarkus application that uses Workload Identity to a native image

### DIFF
--- a/servicebus-workload-id/pom.xml
+++ b/servicebus-workload-id/pom.xml
@@ -17,7 +17,7 @@
 
         <azure-identity.version>1.15.4</azure-identity.version>
         <azure-messaging-servicebus.version>7.17.10</azure-messaging-servicebus.version>
-        <quarkus-azure-services.version>1.1.3</quarkus-azure-services.version>
+        <quarkus-azure-services.version>1.1.4</quarkus-azure-services.version>
 
         <maven-compiler-plugin.version>3.14.0</maven-compiler-plugin.version>
         <maven-surefire-plugin.version>3.5.3</maven-surefire-plugin.version>

--- a/servicebus-workload-id/src/main/resources/application.properties
+++ b/servicebus-workload-id/src/main/resources/application.properties
@@ -9,6 +9,6 @@ quarkus.container-image.tag=latest
 quarkus.native.remote-container-build=true
 
 quarkus.native.additional-build-args=\
+  --enable-url-protocols=https,\
   --initialize-at-run-time=com.microsoft.azure.proton.transport.ws.impl.Utils,\
-  --initialize-at-run-time=com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl,\
-  --initialize-at-run-time=com.microsoft.aad.msal4jextensions.persistence.linux.ISecurityLibrary
+  --initialize-at-run-time=com.microsoft.azure.proton.transport.proxy.impl.DigestProxyChallengeProcessorImpl


### PR DESCRIPTION
## Context
We fixed the issue about compiling a Quarkus application that uses Workload Identity to a native image in the upstream with this [PR](https://github.com/quarkiverse/quarkus-azure-services/pull/378).


## Test

- Result of running `./mvnw clean package -Dnative -Dquarkus.container-image.build` in **servicebus-workload-id**
- ![image](https://github.com/user-attachments/assets/bd8cbf25-16e5-411e-90a3-27b11f3593b5)

